### PR TITLE
ajout de cette commande /var/www/project/var/log dans le dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN mkdir project
 COPY . project
 COPY vhosts.conf /etc/apache2/sites-enabled
 RUN /etc/init.d/apache2 restart
-RUN chmod -R 777 project/var/cache
+RUN chmod -R 777 project/var/cache /var/www/project/var/log
 CMD ["apache2ctl", "-D", "FOREGROUND"]
 EXPOSE 80


### PR DESCRIPTION
J'ai modifié le Dockerfile pour corriger les permissions des répertoires logs (RUN chmod -R 777 project/var/cache /var/www/project/var/log) .
Merci de vérifier ces changements et de les fusionner si tu es d'accord.
